### PR TITLE
(Landscaper: bump can-stache-key to ^0.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "can-symbol": "^1.0.0-pre.0",
     "can-types": "^1.1.0-pre.1",
     "can-util": "^3.9.4",
-    "can-stache-key": "0.0.4"
+    "can-stache-key": "^0.1.0"
   },
   "devDependencies": {
     "jshint": "^2.9.1",


### PR DESCRIPTION
This pull request was created with [Landscaper](https://github.com/bitovi/landscaper).
The following code mods were used to create this PR:

1. **https://gist.githubusercontent.com/bgando/f027191e9601c694e0e23e3a46f28e70/raw/eebfc5c1104e6863b5fa40ac4abd33dcc6bca6f4/bump-can-stache-key-version.js**

Please review this PR carefully as Landscaper does not guarantee any code mod's quality.