### PR TITLE
Makes _legacyAttrBehavior work for serialize()

### DIFF
--- a/can-map.js
+++ b/can-map.js
@@ -461,7 +461,11 @@ var Map = Construct.extend(
 		// Serializes a property.  Uses map helpers to
 		// recursively serialize nested observables.
 		___serialize: function(name, val){
-			return canReflect.serialize(val, CIDMap);
+			if(this._legacyAttrBehavior) {
+				return mapHelpers.getValue(this, name, val, "serialize");
+			} else {
+				return canReflect.serialize(val, CIDMap);
+			}
 		},
 
 		// ### _getAttrs

--- a/can-map_test.js
+++ b/can-map_test.js
@@ -498,3 +498,17 @@ QUnit.test(".attr() leaves typed instances alone if _legacyAttrBehavior is true 
 
 	delete Map.prototype._legacyAttrBehavior;
 });
+
+QUnit.test(".serialize() leaves typed instances alone if _legacyAttrBehavior is true", function(){
+	function MyClass(value) {
+		this.value = value;
+	}
+
+	var myMap = new Map({
+		_legacyAttrBehavior: true,
+		myClass: new MyClass('foo')
+	});
+
+	var ser = myMap.serialize();
+	QUnit.equal(ser.myClass, myMap.attr("myClass"));
+});


### PR DESCRIPTION
This makes the recently added _legacyAttrBehavior work for serialize()
in addition to the existing .attr() behavior.