### PR TITLE
Makes deep assigns and updates work with _legacyAttrBehavior

### DIFF
--- a/can-map.js
+++ b/can-map.js
@@ -524,7 +524,11 @@ var Map = Construct.extend(
 				}
 
 				if ( types.isMapLike(curVal) && mapHelpers.canMakeObserve(newVal) ) {
-					curVal.attr(newVal, remove);
+					if(remove === true) {
+						canReflect.updateDeep(curVal, newVal);
+					} else {
+						canReflect.assignDeep(curVal, newVal);
+					}
 					// Otherwise just set.
 				} else if (curVal !== newVal) {
 					self.__set(prop, self.__type(newVal, prop), curVal);

--- a/can-map_test.js
+++ b/can-map_test.js
@@ -512,3 +512,37 @@ QUnit.test(".serialize() leaves typed instances alone if _legacyAttrBehavior is 
 	var ser = myMap.serialize();
 	QUnit.equal(ser.myClass, myMap.attr("myClass"));
 });
+
+QUnit.test("Can assign nested properties that are not CanMaps", function(){
+	var MyType = function() {
+		this.one = 'one';
+		this.two = 'two';
+		this.three = 'three';
+	};
+	MyType.prototype[canSymbol.for("can.onKeyValue")] = function(){};
+	MyType.prototype[canSymbol.for("can.isMapLike")] = true;
+
+	var map = new Map({
+		_legacyAttrBehavior: true,
+		foo: 'bar',
+		prop: new MyType()
+	});
+
+	map.attr({
+		prop: {one: '1', two: '2'}
+	});
+
+	// Did an assign
+	QUnit.equal(map.attr("prop.one"), "1");
+	QUnit.equal(map.attr("prop.two"), "2");
+	QUnit.equal(map.attr("prop.three"), "three");
+
+	// An update
+	map.attr({
+		prop: {one: 'one', two: 'two'}
+	}, true);
+
+	QUnit.equal(map.attr("prop.one"), "one");
+	QUnit.equal(map.attr("prop.two"), "two");
+	QUnit.equal(map.attr("prop.three"), undefined);
+});


### PR DESCRIPTION
When using `_legacyAttrBehavior: true` to enable the legacy attr
behavior you still want to interop with other map types. For this to
work:

```js
map.attr({
  prop: new DefineMap()
})
```

This works with both assign and update forms of attr().

Fixes #119