### PR TITLE
84 dropping keys

### DIFF
--- a/can-map.js
+++ b/can-map.js
@@ -377,7 +377,7 @@ var Map = Construct.extend(
 		// Calls `___set` to do the actual setting.
 		__set: function (prop, value, current) {
 
-			if ( value !== current || this.__inSetup ) {
+			if ( value !== current || !Object.prototype.hasOwnProperty.call( this._data, prop ) ) {
 				var computedAttr = this._computedAttrs[prop];
 
 				// Dispatch an "add" event if adding a new property.

--- a/can-map.js
+++ b/can-map.js
@@ -377,7 +377,7 @@ var Map = Construct.extend(
 		// Calls `___set` to do the actual setting.
 		__set: function (prop, value, current) {
 
-			if (value !== current) {
+			if ( value !== current || this.__inSetup ) {
 				var computedAttr = this._computedAttrs[prop];
 
 				// Dispatch an "add" event if adding a new property.

--- a/can-map_test.js
+++ b/can-map_test.js
@@ -598,7 +598,7 @@ QUnit.test(".serialize() leaves typed instances alone if _legacyAttrBehavior is 
 
 QUnit.test("keys with undefined values should not be dropped (issue#84)", function() {
 	// handles new instances
-	obj1 = { "keepMe": undefined };
+	var obj1 = { "keepMe": undefined };
 	var map = new Map(obj1);
 	// handles late props
 	map.attr('foo', undefined);

--- a/can-map_test.js
+++ b/can-map_test.js
@@ -596,7 +596,7 @@ QUnit.test(".serialize() leaves typed instances alone if _legacyAttrBehavior is 
 	QUnit.equal(ser.myClass, myMap.attr("myClass"));
 });
 
-QUnit.test("keys with undefined values should not be dropped (issue#84)", function() {
+QUnit.test("keys with undefined values should not be dropped (#118)", function() {
 	// handles new instances
 	var obj1 = { "keepMe": undefined };
 	var map = new Map(obj1);

--- a/can-map_test.js
+++ b/can-map_test.js
@@ -596,10 +596,14 @@ QUnit.test(".serialize() leaves typed instances alone if _legacyAttrBehavior is 
 	QUnit.equal(ser.myClass, myMap.attr("myClass"));
 });
 
-QUnit.test("keys with undefined values should not be dropped", function() {
+QUnit.test("keys with undefined values should not be dropped (issue#84)", function() {
+	// handles new instances
 	obj1 = { "keepMe": undefined };
 	var map = new Map(obj1);
+	// handles late props
+	map.attr('foo', undefined);
+
 	var keys = Map.keys(map);
 
-	QUnit.deepEqual( keys, ["keepMe"]);
+	QUnit.deepEqual(keys, ["keepMe", "foo"])
 });

--- a/can-map_test.js
+++ b/can-map_test.js
@@ -595,3 +595,11 @@ QUnit.test(".serialize() leaves typed instances alone if _legacyAttrBehavior is 
 	var ser = myMap.serialize();
 	QUnit.equal(ser.myClass, myMap.attr("myClass"));
 });
+
+QUnit.test("keys with undefined values should not be dropped", function() {
+	obj1 = { "keepMe": undefined };
+	var map = new Map(obj1);
+	var keys = Map.keys(map);
+
+	QUnit.deepEqual( keys, ["keepMe"]);
+});


### PR DESCRIPTION
Keys with values that were `undefined` were being dropped. This checks if the key/prop is missing from `this._data` and adds it with it's current value of `undefined` if it is not already there.

closes #118 