### PR TITLE
Fix `can-types.isMapLike(obj)` deprecated warning

### DIFF
--- a/can-map.js
+++ b/can-map.js
@@ -534,7 +534,7 @@ var Map = Construct.extend(
 					newVal = self.__convert( prop, newVal );
 				}
 
-				if ( types.isMapLike(curVal) && mapHelpers.canMakeObserve(newVal) ) {
+				if ( canReflect.isObservableLike(curVal) && canReflect.isMapLike(curVal) && mapHelpers.canMakeObserve(newVal) ) {
 					if(remove === true) {
 						canReflect.updateDeep(curVal, newVal);
 					} else {


### PR DESCRIPTION
Replace usage of `can-types.isMapLike(obj)` by `canReflect.isObservableLike(obj) && canReflect.isMapLike(obj)`

Fix issue #129