### PR TITLE
Children don't bubble parent with functions

### DIFF
--- a/bubble.js
+++ b/bubble.js
@@ -192,7 +192,7 @@ var bubble = {
 		childrenOf: function (parent, eventName) {
 
 			parent._each(function (child, prop) {
-				if (child && !canReflect.isFunctionLike(child) && child.bind) {
+				if (child && !canReflect.isFunctionLike(child) && canReflect.isMapLike(child)) {
 					bubble.toParent(child, parent, prop, eventName);
 				}
 			});

--- a/bubble.js
+++ b/bubble.js
@@ -144,7 +144,7 @@ var bubble = {
 		// For an event binding on an object, returns the events that should be bubbled.
 		// For example, `"change" -> ["change"]`.
 		events: function(map, boundEventName) {
-			if (map && typeof map === 'object') {
+			if (map && !canReflect.isFunctionLike(map)) {
 				return map.constructor._bubbleRule(boundEventName, map);
 			}
 		},
@@ -192,7 +192,7 @@ var bubble = {
 		childrenOf: function (parent, eventName) {
 
 			parent._each(function (child, prop) {
-				if (child && typeof child === "object" && child.bind) {
+				if (child && !canReflect.isFunctionLike(child) && child.bind) {
 					bubble.toParent(child, parent, prop, eventName);
 				}
 			});

--- a/bubble.js
+++ b/bubble.js
@@ -144,7 +144,9 @@ var bubble = {
 		// For an event binding on an object, returns the events that should be bubbled.
 		// For example, `"change" -> ["change"]`.
 		events: function(map, boundEventName) {
-			return map.constructor._bubbleRule(boundEventName, map);
+			if (map && typeof map === 'object') {
+				return map.constructor._bubbleRule(boundEventName, map);
+			}
 		},
 
 
@@ -190,7 +192,7 @@ var bubble = {
 		childrenOf: function (parent, eventName) {
 
 			parent._each(function (child, prop) {
-				if (child && child.bind) {
+				if (child && typeof child === "object" && child.bind) {
 					bubble.toParent(child, parent, prop, eventName);
 				}
 			});

--- a/bubble_test.js
+++ b/bubble_test.js
@@ -1,0 +1,27 @@
+var QUnit = require("steal-qunit");
+var CanMap = require("./can-map");
+var bubble = require("./bubble");
+
+QUnit.test(".childrenOf should not bubble functions", function(assert){
+	var map = new CanMap({
+		fn: function() {}
+	});
+
+	bubble.childrenOf(map, "change");
+
+	assert.equal(bubble.events(map.fn, "change"), undefined, "Functions are not bubbled");
+});
+
+QUnit.test(".childrenOf should not bubble functions in nested maps", function(assert){
+	var map = new CanMap({
+		obj: {
+			fooFn: function() {},
+			foo: { bar: "baz" }
+		}
+	});
+
+	bubble.childrenOf(map, "change");
+
+	assert.equal(bubble.events(map.attr("obj").fooFn, "change"), undefined, "Nested maps functions are not bubbled");
+	assert.equal(bubble.events(map.attr("obj.foo"), "change").length, 1, "Still bubbles nested maps");
+});

--- a/test/test.js
+++ b/test/test.js
@@ -1,1 +1,2 @@
 import '../can-map_test';
+import '../bubble_test';


### PR DESCRIPTION
This is needed to fix https://github.com/canjs/can-list/issues/97

### The issue
An error is thrown when function events is bubbled to parent, the check is made by `.bind` 
https://github.com/canjs/can-map/blob/2f72c0f8d0d7623276ac666969617ebc4e05a123/bubble.js#L193
for that reason, functions are always bubbled.

### The changes
- Update `childrenOf` in `bubble.js` to bubble events to parent only on `Objects`/`Map`
- Make a test file for `bubble.js`