### PR TITLE
Fix array bubbling

### DIFF
--- a/bubble.js
+++ b/bubble.js
@@ -26,6 +26,12 @@ var canEvent = require('can-event-queue/map/map');
 
 var canReflect = require('can-reflect');
 
+// Helper function to check the Map type
+var isMap = function(map) {
+	return (map && !canReflect.isFunctionLike(map) && 
+			canReflect.isMapLike(map) && !Array.isArray(map));
+};
+
 
 var bubble = {
 		// ## bubble.bind
@@ -144,7 +150,7 @@ var bubble = {
 		// For an event binding on an object, returns the events that should be bubbled.
 		// For example, `"change" -> ["change"]`.
 		events: function(map, boundEventName) {
-			if (map && !canReflect.isFunctionLike(map)) {
+			if (isMap(map)) {
 				return map.constructor._bubbleRule(boundEventName, map);
 			}
 		},
@@ -192,7 +198,7 @@ var bubble = {
 		childrenOf: function (parent, eventName) {
 
 			parent._each(function (child, prop) {
-				if (child && !canReflect.isFunctionLike(child) && canReflect.isMapLike(child)) {
+				if (isMap(child)) {
 					bubble.toParent(child, parent, prop, eventName);
 				}
 			});

--- a/bubble_test.js
+++ b/bubble_test.js
@@ -25,3 +25,17 @@ QUnit.test(".childrenOf should not bubble functions in nested maps", function(as
 	assert.equal(bubble.events(map.attr("obj").fooFn, "change"), undefined, "Nested maps functions are not bubbled");
 	assert.equal(bubble.events(map.attr("obj.foo"), "change").length, 1, "Still bubbles nested maps");
 });
+
+QUnit.test(".childrenOf should not bubble array", function(assert){
+	var map = new CanMap({
+		foo: ['item'],
+		bar: {
+			baz: ['anotherItem']
+		}
+	});
+	bubble.childrenOf(map, "change");
+	assert.equal(bubble.events(map.attr("foo"), "change"), undefined);
+	assert.equal(bubble.events(map.attr("bar.baz"), "change"), undefined);
+	
+	assert.ok(true);
+});


### PR DESCRIPTION
Fixes #147 

This fixes integration with `can-map-define`, `can-map` tries to bind events for array which causes an error.