### PR TITLE
Only bubble observable children

### DIFF
--- a/bubble.js
+++ b/bubble.js
@@ -28,8 +28,13 @@ var canReflect = require('can-reflect');
 
 // Helper function to check the Map type
 var isMap = function(map) {
-	return (map && !canReflect.isFunctionLike(map) && 
-			canReflect.isMapLike(map) && !Array.isArray(map));
+	return (
+		map &&
+		!canReflect.isFunctionLike(map) && 
+		canReflect.isMapLike(map) &&
+		!Array.isArray(map) &&
+		canReflect.isObservableLike(map)
+	);
 };
 
 
@@ -198,7 +203,7 @@ var bubble = {
 		childrenOf: function (parent, eventName) {
 
 			parent._each(function (child, prop) {
-				if (isMap(child) && canReflect.isObservableLike(child)) {
+				if (isMap(child)) {
 					bubble.toParent(child, parent, prop, eventName);
 				}
 			});

--- a/bubble.js
+++ b/bubble.js
@@ -194,11 +194,11 @@ var bubble = {
 		},
 
 		// ## bubble.childrenOf
-		// Bubbles all the children of `parent`.
+		// Bubbles all the observable children of `parent`.
 		childrenOf: function (parent, eventName) {
 
 			parent._each(function (child, prop) {
-				if (isMap(child)) {
+				if (isMap(child) && canReflect.isObservableLike(child)) {
 					bubble.toParent(child, parent, prop, eventName);
 				}
 			});

--- a/bubble_test.js
+++ b/bubble_test.js
@@ -39,3 +39,14 @@ QUnit.test(".childrenOf should not bubble array", function(assert){
 	
 	assert.ok(true);
 });
+
+QUnit.test(".childrenOf should not bind nested non-Observables", function(assert){
+
+	var map = new CanMap({
+			type: Object.create({
+				label: "hello",
+			})
+	});
+	bubble.childrenOf(map, "change");
+	assert.ok(true, "Bubble children does not error");
+});

--- a/bubble_test.js
+++ b/bubble_test.js
@@ -48,5 +48,8 @@ QUnit.test(".childrenOf should not bind nested non-Observables", function(assert
 			})
 	});
 	bubble.childrenOf(map, "change");
-	assert.ok(true, "Bubble children does not error");
+	assert.equal(bubble.events(map.attr("type"), "change"), undefined, "non-Observable child does not bubble");
+	map.attr("type", new CanMap({}));
+	assert.equal(bubble.events(map.attr("type"), "change").length, 1, "replacing with Observable child bubbles");
+
 });


### PR DESCRIPTION
This prevents errors being thrown when a CanMap has a child element that is a MapLike but not observable (e.g. "plain" objects with a proto other than Object.prototype).

Fixes #149 